### PR TITLE
fix: Ensure correct venv usage for backend in start_dev.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # TomeTroveWeb
+
+## Simplified Development Setup
+
+This project includes a convenience script `start_dev.sh` to simplify the development setup process by starting both the backend and frontend servers concurrently.
+
+### Purpose
+
+The `start_dev.sh` script automates the following:
+- Starting the Python backend server.
+- Starting the Node.js frontend development server.
+- Creation of Python virtual environment and installation of backend dependencies if not already set up.
+- Installation of frontend Node modules if not already set up.
+
+### Prerequisites
+
+Before running the script, ensure you have the following installed:
+- Python 3 (python3)
+- Node.js
+- npm (usually comes with Node.js) or yarn
+- `concurrently`: This is a Node.js package used to run multiple commands concurrently. If `concurrently` is not installed globally, the script will detect this and provide instructions on how to install it (e.g., `npm install -g concurrently` or `yarn global add concurrently`).
+
+### How to Run
+
+1. Open your terminal.
+2. Navigate to the root directory of the project.
+3. Make the script executable (if you haven't already):
+   ```bash
+   chmod +x start_dev.sh
+   ```
+4. Run the script:
+   ```bash
+   ./start_dev.sh
+   ```
+This will start both the backend and frontend development servers. You should see output from both servers in your terminal.

--- a/start_dev.sh
+++ b/start_dev.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Check if concurrently is installed
+if ! command -v concurrently &> /dev/null
+then
+    echo "concurrently could not be found. Please install it globally:"
+    echo "npm install -g concurrently"
+    echo "or"
+    echo "yarn global add concurrently"
+    echo "Alternatively, install it as a dev dependency in your project's root: npm install --save-dev concurrently"
+    echo "If installed as a dev dependency, you might need to run this script using 'npx ./start_dev.sh' or adjust the 'concurrently' command to 'npx concurrently'"
+    exit
+fi
+
+echo "Starting backend and frontend concurrently..."
+
+concurrently \
+  "cd backend && python3 -m venv venv && ./venv/bin/pip install -r requirements.txt && ./venv/bin/python app.py" \
+  "cd frontend && (if [ ! -d 'node_modules' ]; then npm install; fi) && npm run dev"


### PR DESCRIPTION
The previous version of `start_dev.sh` could fail to activate the backend's Python virtual environment correctly when run via `concurrently`, leading to `ModuleNotFoundError` if dependencies like Flask were not globally available.

This commit modifies the backend command within `concurrently` to:
1. Explicitly create the virtual environment (`python3 -m venv venv`) if it doesn't exist.
2. Directly use the `pip` executable from the venv (`./venv/bin/pip`) to install dependencies.
3. Directly use the `python` executable from the venv (`./venv/bin/python`) to run `app.py`.

This more explicit approach ensures that the backend always runs within its intended isolated environment with the correct dependencies.

The message for missing `concurrently` was also updated to suggest using `npx` if `concurrently` is installed as a local dev dependency.